### PR TITLE
(BKR-1044) add in boiler-plate include mechanism

### DIFF
--- a/lib/beaker-facter.rb
+++ b/lib/beaker-facter.rb
@@ -9,3 +9,17 @@ module Beaker
     end
   end
 end
+
+# Boilerplate DSL inclusion mechanism:
+# First we register our module with the Beaker DSL
+Beaker::DSL.register( Beaker::DSL::Helpers::Facter )
+
+# Second,We need to reload the DSL, but before we had reloaded
+# it in the global namespace, which result in errors colliding
+# with other gems rightfully not expecting beaker's dsl to
+# be available at the global level.
+module Beaker
+  class TestCase
+    include Beaker::DSL
+  end
+end


### PR DESCRIPTION
Previous to this commit, we did not have any of beaker's boiler plate
for including beaker-libraries in this repo; this adds in the mechanism
where the DSL's register method is called and then the DSL is reloaded
to include the new library.