### PR TITLE
Revert "(BKR-1044) add in boiler-plate include mechanism"

### DIFF
--- a/lib/beaker-facter.rb
+++ b/lib/beaker-facter.rb
@@ -9,17 +9,3 @@ module Beaker
     end
   end
 end
-
-# Boilerplate DSL inclusion mechanism:
-# First we register our module with the Beaker DSL
-Beaker::DSL.register( Beaker::DSL::Helpers::Facter )
-
-# Second,We need to reload the DSL, but before we had reloaded
-# it in the global namespace, which result in errors colliding
-# with other gems rightfully not expecting beaker's dsl to
-# be available at the global level.
-module Beaker
-  class TestCase
-    include Beaker::DSL
-  end
-end


### PR DESCRIPTION
This reverts commit 3b9ae70c6848c1218bb3b888855687ec8e496fd2.

Because beaker requires 'beaker-facter' in the gemspec, beaker-facter's own code is executed before the DSL from beaker itself, and thus including beaker-facter will break on no register method being defined for Beaker::DSL.